### PR TITLE
u-boot: Enable PE and PUE flags on UART Pins during early boot

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx/0001-patching-for-kimchi.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0001-patching-for-kimchi.patch
@@ -749,7 +749,7 @@ index 0000000000..0d54324c3d
 +
 +DECLARE_GLOBAL_DATA_PTR;
 +
-+#define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1)
++#define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1 | PAD_CTL_PUE | PAD_CTL_PE)
 +#define WDOG_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_ODE | PAD_CTL_PUE | PAD_CTL_PE)
 +
 +static iomux_v3_cfg_t const uart_pads[] = {

--- a/recipes-bsp/u-boot/u-boot-imx/0001-patching-for-mxenc.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0001-patching-for-mxenc.patch
@@ -2467,7 +2467,7 @@ index 0000000000..375c2ad8fc
 +
 +DECLARE_GLOBAL_DATA_PTR;
 +
-+#define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1)
++#define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1 | PAD_CTL_PUE | PAD_CTL_PE)
 +#define WDOG_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_ODE | PAD_CTL_PUE | PAD_CTL_PE)
 +
 +static iomux_v3_cfg_t const uart_pads[] = {

--- a/recipes-bsp/u-boot/u-boot-imx/0003-set-battery-chemistry-at-boot.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0003-set-battery-chemistry-at-boot.patch
@@ -228,7 +228,7 @@ index 0d54324c3d..d2436d06db 100644
  
 +int setup_bq27426(int i2c_bus, uint8_t addr);
 +
- #define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1)
+ #define UART_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_FSEL1 | PAD_CTL_PUE | PAD_CTL_PE)
  #define WDOG_PAD_CTRL	(PAD_CTL_DSE6 | PAD_CTL_ODE | PAD_CTL_PUE | PAD_CTL_PE)
  
 @@ -55,7 +57,7 @@ int board_early_init_f(void)


### PR DESCRIPTION
The kimchi-board went into u-boot, as the rx-tx pins were left floating
before device tree was configured. The pins picked up noise and somehow
the board got an input, thus skipped loading the kernel.

Added Pull Enable (PE) and Pull Up Enable (PUE) flags on the uart rx/tx
pins during early boot.

Signed-off-by: Vedant Paranjape <22630228+VedantParanjape@users.noreply.github.com>